### PR TITLE
[Feat] 매수/매도 호가 데이터 증가 및 주가변동률 예외처리 추가

### DIFF
--- a/client/src/components/StockOrderSection/PriceSetting.tsx
+++ b/client/src/components/StockOrderSection/PriceSetting.tsx
@@ -18,8 +18,9 @@ const PriceSetting = (props: OwnProps) => {
   const [priceChangeTimer, setPriceChangeTimer] = useState<NodeJS.Timeout | null>(null);
 
   // 초기 설정값 및 가격 변동폭 설정
-  const { askp1, askp2, askp3, askp4, askp5 } = stockInfo;
-  const sellingPrice = [parseInt(askp1), parseInt(askp2), parseInt(askp3), parseInt(askp4), parseInt(askp5)];
+  const { askp1, askp2, askp3, askp4, askp5, askp6, askp7, askp8, askp9, askp10 } = stockInfo;
+  const sellingInfo = [askp1, askp2, askp3, askp4, askp5, askp6, askp7, askp8, askp9, askp10];
+  const sellingPrice = sellingInfo.map((price) => parseInt(price));
   const existSellingPrice = sellingPrice.filter((price) => price !== 0); // price 0인 경우 제거
   const defaultPrice = existSellingPrice[0];
   const priceInterval = existSellingPrice[1] - existSellingPrice[0];
@@ -28,8 +29,9 @@ const PriceSetting = (props: OwnProps) => {
   const orderType = useSelector((state: StateProps) => state.stockOrderType);
   const [orderPossibility, setOrderPossibility] = useState(true);
 
-  const { bidp1, bidp2, bidp3, bidp4, bidp5 } = stockInfo;
-  const buyingPrice = [parseInt(bidp1), parseInt(bidp2), parseInt(bidp3), parseInt(bidp4), parseInt(bidp5)];
+  const { bidp1, bidp2, bidp3, bidp4, bidp5, bidp6, bidp7, bidp8, bidp9, bidp10 } = stockInfo;
+  const buyingInfo = [bidp1, bidp2, bidp3, bidp4, bidp5, bidp6, bidp7, bidp8, bidp9, bidp10];
+  const buyingPrice = buyingInfo.map((price) => parseInt(price));
   const existBuyingPrice = buyingPrice.filter((price) => price !== 0); // price 0인 경우 제거
 
   // 거래 가능여부 판별 함수

--- a/client/src/components/StockOrderSection/StockPriceList.tsx
+++ b/client/src/components/StockOrderSection/StockPriceList.tsx
@@ -23,7 +23,7 @@ const StockPriceList = () => {
   const sellingPrice: PriceProps[] = [];
   const buyingPrice: PriceProps[] = [];
 
-  for (let i = 1; i < 6; i++) {
+  for (let i = 1; i < 11; i++) {
     const sellingPriceProp = `askp${i}`; // 매도 호가
     const sellingVolumeProp = `askp_rsqn${i}`; // 해당 매도호가 거래량
     const buyingPriceProp = `bidp${i}`; // 매수 호가
@@ -43,24 +43,9 @@ const StockPriceList = () => {
     buyingPrice.push(buyingInfo);
   }
 
-  /*
-  🔴 삭제 예정인 코드
-  [문제점] 주가 리스트 개수가 너무 적음 (매도호가 5개 + 매수호가 5개 = 총 10개) → UX를 저해하는 요소로 판단되어, 더미데이터를 추가 (매도/매수 각각 5개씩)
-  [해결방안] 1) fetching 해온 데이터 중 가격 0인 데이터 제외 (한국투자증권 API에서 간혹 보내는 경우 있음) → 호가 간격 계산 후, 더미 데이터 추가 (거래량은 0으로 설정)
-  */
+  // price 0인 경우 제외
   const existSellingPrice = sellingPrice.filter((selling) => selling.price !== 0);
   const existBuyingPrice = buyingPrice.filter((buyingPrice) => buyingPrice.price !== 0);
-  // const priceInterval: number = existSellingPrice[existSellingPrice.length - 1].price - existBuyingPrice[0].price;
-
-  // for (let i = 0; existSellingPrice.length < 10; i++) {
-  //   const dummySellingData = { price: existSellingPrice[0].price + priceInterval, volume: 0 };
-  //   existSellingPrice.unshift(dummySellingData);
-  // }
-
-  // for (let i = 0; existBuyingPrice.length < 10; i++) {
-  //   const dummyBuyingData = { price: existBuyingPrice[existBuyingPrice.length - 1].price - priceInterval, volume: 0 };
-  //   existBuyingPrice.push(dummyBuyingData);
-  // }
 
   // 1) 매도/매수호가 종합  2) 매수/매도호가 거래량 종합
   const sellingAndBuyingPrice = [...existSellingPrice, ...existBuyingPrice];

--- a/client/src/models/stockInfoProps.ts
+++ b/client/src/models/stockInfoProps.ts
@@ -6,21 +6,41 @@ export interface StockInfoProps {
   askp3: string;
   askp4: string;
   askp5: string;
+  askp6: string;
+  askp7: string;
+  askp8: string;
+  askp9: string;
+  askp10: string;
   askp_rsqn1: string;
   askp_rsqn2: string;
   askp_rsqn3: string;
   askp_rsqn4: string;
   askp_rsqn5: string;
+  askp_rsqn6: string;
+  askp_rsqn7: string;
+  askp_rsqn8: string;
+  askp_rsqn9: string;
+  askp_rsqn10: string;
   bidp1: string;
   bidp2: string;
   bidp3: string;
   bidp4: string;
   bidp5: string;
+  bidp6: string;
+  bidp7: string;
+  bidp8: string;
+  bidp9: string;
+  bidp10: string;
   bidp_rsqn1: string;
   bidp_rsqn2: string;
   bidp_rsqn3: string;
   bidp_rsqn4: string;
   bidp_rsqn5: string;
+  bidp_rsqn6: string;
+  bidp_rsqn7: string;
+  bidp_rsqn8: string;
+  bidp_rsqn9: string;
+  bidp_rsqn10: string;
 }
 
 // export interface StockInfoprops {


### PR DESCRIPTION
- 매수/매도호가 관련 BE 데이터 증가로 인하여 화면에 렌더링 되는 주가 리스트 개수 증가 (기존에 활용하던 더미 데이터 로직 삭제)
- 주가변동률 계산 시 전날 주가 데이터가 넘어오지 않을 시 (데이터 초기화 등의 사유로) 임의로 전날 종가를 0으로 설정하여 처리
- 이후 예외처리 보완 예정이며 현재는 BE-FE 통합 테스트가 예정되어 있어 시간 문제로 임의로 0으로 설정