### PR TITLE
[FE] 미체결 거래 체결전환 알림 관련 수정

### DIFF
--- a/client/src/components/StockOrderSection/WaitOrderIndicator.tsx
+++ b/client/src/components/StockOrderSection/WaitOrderIndicator.tsx
@@ -14,10 +14,14 @@ const WaitOrderIndicator = () => {
 
   useEffect(() => {
     if (waitOrderSuccessData) {
-      toast.info(`대기주문이 체결되었습니다`, {
-        style: toastStyle,
-        position: "bottom-left",
-      });
+      console.log(waitOrderSuccessData);
+
+      if (waitOrderSuccessData[0].length !== 0 && waitOrderSuccessData[1].length !== 0) {
+        toast.info(`대기주문이 체결되었습니다`, {
+          style: toastStyle,
+          position: "bottom-left",
+        });
+      }
     }
   }, [waitOrderSuccessData]);
 


### PR DESCRIPTION
- 서버에서 빈배열 (체결 전환된 것이 없을 때 반환되는 response) 수신 시, 알림 메세지 띄우지 않도록 수정