### PR TITLE
[FE]리프레시 토큰을 이용한 로그인 유지 기능 Dev client#19/watch list

### DIFF
--- a/client/src/hooks/customHooks/useAutoLogout.ts
+++ b/client/src/hooks/customHooks/useAutoLogout.ts
@@ -7,6 +7,30 @@ import { secondAlarmTime, lastAlarmTime } from '../../utils/setAutoLogoutAlarm';
 const useAutoLogout = () => {
   const dispatch = useDispatch();
 
+  // 리프레시 토큰을 사용하여 새 엑세스 토큰을 요청하는 함수
+  const requestNewAccessToken = async () => {
+    const refreshToken = localStorage.getItem("refreshToken");
+    try {
+      const response = await fetch('http://ec2-13-125-246-160.ap-northeast-2.compute.amazonaws.com:8080/tokens/refresh', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ refreshToken: refreshToken })
+      });
+
+      if (response.status !== 201) {
+        throw new Error('Failed to fetch new access token');
+    }
+
+      const data = await response.json();
+      return data.accessToken;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  };
+
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
     if (accessToken !== null) {
@@ -15,29 +39,35 @@ const useAutoLogout = () => {
       const autoLogoutLastAlarm = localStorage.getItem('autoLogoutLastAlarm');
 
       if (autoLogoutSecondAlarm !== null) {
-        if (currentTime >= parseInt(autoLogoutSecondAlarm) + secondAlarmTime + lastAlarmTime) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          localStorage.removeItem('autoLogoutSecondAlarm');
-        } else {
-          const timeGone = currentTime - parseInt(autoLogoutSecondAlarm);
-          const remainTime = secondAlarmTime - timeGone;
-          dispatch(setLoginState());
-          setAutoLogoutAlarm(dispatch, 'second', remainTime, lastAlarmTime);
-        }
+        if (currentTime >= parseInt(autoLogoutSecondAlarm) + secondAlarmTime) {
+          requestNewAccessToken().then(newAccessToken => {
+            if (newAccessToken) {
+              localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
+              dispatch(setLoginState());
+              setAutoLogoutAlarm(dispatch, 'second', secondAlarmTime, lastAlarmTime);
+            } else {
+              localStorage.removeItem('accessToken');
+              localStorage.removeItem('refreshToken');
+              localStorage.removeItem('autoLogoutSecondAlarm');
+            }
+          });
+        } 
       }
 
       if (autoLogoutLastAlarm !== null) {
         if (currentTime >= parseInt(autoLogoutLastAlarm) + lastAlarmTime) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          localStorage.removeItem('autoLogoutLastAlarm');
-        } else {
-          const timeGone = currentTime - parseInt(autoLogoutLastAlarm);
-          const remainTime = lastAlarmTime - timeGone;
-          dispatch(setLoginState());
-          setAutoLogoutAlarm(dispatch, 'last', remainTime);
-        }
+          requestNewAccessToken().then(newAccessToken => {
+            if (newAccessToken) {
+              localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
+              dispatch(setLoginState());
+              setAutoLogoutAlarm(dispatch, 'last', lastAlarmTime);
+            } else {
+              localStorage.removeItem('accessToken');
+              localStorage.removeItem('refreshToken');
+              localStorage.removeItem('autoLogoutLastAlarm');
+            }
+          });
+        } 
       }
     }
   }, [dispatch]);

--- a/client/src/hooks/customHooks/useOAuthLogin.ts
+++ b/client/src/hooks/customHooks/useOAuthLogin.ts
@@ -5,58 +5,84 @@ import setAutoLogoutAlarm from '../../utils/setAutoLogoutAlarm';
 import { secondAlarmTime, lastAlarmTime } from '../../utils/setAutoLogoutAlarm';
 
 const useOAuthLogin = () => {
-  const dispatch = useDispatch();
+    const dispatch = useDispatch();
 
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const accessToken = urlParams.get('access_token');
-    const refreshToken = urlParams.get('refresh_token');
-    const currentTime = Date.now();
-    const autoLogoutSecondAlarm = localStorage.getItem('autoLogoutSecondAlarm');
-    const autoLogoutLastAlarm = localStorage.getItem('autoLogoutLastAlarm');
+    // 리프레시 토큰을 사용하여 새 엑세스 토큰을 요청하는 함수
+    const requestNewAccessToken = async () => {
+        const refreshToken = localStorage.getItem("refreshToken");
+        try {
+            const response = await fetch('http://ec2-13-125-246-160.ap-northeast-2.compute.amazonaws.com:8080/tokens/refresh', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ refreshToken: refreshToken })
+            });
 
-    if (accessToken && refreshToken) {
-      localStorage.setItem('accessToken', `Bearer ${accessToken}`);
-      localStorage.setItem('refreshToken', refreshToken);
+            if (response.status !== 201) {
+              throw new Error('Failed to fetch new access token');
+          }
 
-      urlParams.delete('access_token');
-      urlParams.delete('refresh_token');
-      window.history.replaceState({}, '', '?' + urlParams.toString());
-
-      if (autoLogoutSecondAlarm === null) {
-        dispatch(setLoginState()); // 로그인 처리
-        setAutoLogoutAlarm(dispatch, 'first', secondAlarmTime, lastAlarmTime);
-      }
-
-      if (autoLogoutSecondAlarm !== null) {
-        if (currentTime >= parseInt(autoLogoutSecondAlarm) + secondAlarmTime + lastAlarmTime) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          localStorage.removeItem('autoLogoutSecondAlarm');
-        } else {
-          const timeGone = currentTime - parseInt(autoLogoutSecondAlarm);
-          const remainTime = secondAlarmTime - timeGone
-          dispatch(setLoginState()); // 로그인 처리
-          setAutoLogoutAlarm(dispatch, 'second', remainTime, lastAlarmTime);
+            const data = await response.json();
+            return data.accessToken;
+        } catch (error) {
+            console.error(error);
+            return null;
         }
-      }
+    };
 
-      if (autoLogoutLastAlarm !== null) {
-        if (currentTime >= parseInt(autoLogoutLastAlarm) + lastAlarmTime) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          localStorage.removeItem('autoLogoutLastAlarm');
+    useEffect(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const accessToken = urlParams.get('access_token');
+        const refreshToken = urlParams.get('refresh_token');
+
+        if (accessToken && refreshToken) {
+            localStorage.setItem('accessToken', `Bearer ${accessToken}`);
+            localStorage.setItem('refreshToken', refreshToken);
+
+            urlParams.delete('access_token');
+            urlParams.delete('refresh_token');
+            window.history.replaceState({}, '', '?' + urlParams.toString());
+
+            dispatch(setLoginState()); // 로그인 처리
+            setAutoLogoutAlarm(dispatch, 'first', secondAlarmTime, lastAlarmTime);
         } else {
-          const timeGone = currentTime - parseInt(autoLogoutLastAlarm);
-          const remainTime = lastAlarmTime - timeGone;
-          dispatch(setLoginState()); // 로그인 처리
-          setAutoLogoutAlarm(dispatch, 'last', remainTime);
-        }
-      }
-    }
-  }, [dispatch]);
+            const storedAccessToken = localStorage.getItem('accessToken');
+            const currentTime = Date.now();
+            const autoLogoutSecondAlarm = localStorage.getItem('autoLogoutSecondAlarm');
+            const autoLogoutLastAlarm = localStorage.getItem('autoLogoutLastAlarm');
 
-  return;
+            if (storedAccessToken) {
+                if (autoLogoutSecondAlarm && currentTime >= parseInt(autoLogoutSecondAlarm) + secondAlarmTime) {
+                    requestNewAccessToken().then(newAccessToken => {
+                        if (newAccessToken) {
+                            localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
+                            dispatch(setLoginState());
+                        } else {
+                            localStorage.removeItem('accessToken');
+                            localStorage.removeItem('refreshToken');
+                            localStorage.removeItem('autoLogoutSecondAlarm');
+                        }
+                    });
+                }
+
+                if (autoLogoutLastAlarm && currentTime >= parseInt(autoLogoutLastAlarm) + lastAlarmTime) {
+                    requestNewAccessToken().then(newAccessToken => {
+                        if (newAccessToken) {
+                            localStorage.setItem('accessToken', `Bearer ${newAccessToken}`);
+                            dispatch(setLoginState());
+                        } else {
+                            localStorage.removeItem('accessToken');
+                            localStorage.removeItem('refreshToken');
+                            localStorage.removeItem('autoLogoutLastAlarm');
+                        }
+                    });
+                }
+            }
+        }
+    }, [dispatch]);
+
+    return;
 };
 
 export default useOAuthLogin;


### PR DESCRIPTION
현재 30분 후 자동로그아웃이 구현된 상태
새로 추가 된 부분은 로그인 후 30분이 지난 상태에서 body에 리프레시 토큰을 담아 post요청을 보내고, 성공하면 새 엑세스 토큰을 받아오는 로직 구현
백엔드 서버에 적용이 안된건지 통신 불가 상태(404에러 확인)
Issues #15 